### PR TITLE
fix: live data section api error in production

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,9 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-const LAMBDA_URL = process.env.LAMBDA_URL as string;
+const LAMBDA_URL = process.env.LAMBDA_URL;
 
 // GET - Fetch live analytics data
 export async function GET() {
   try {
+    if (!LAMBDA_URL) {
+      console.error('LAMBDA_URL environment variable is not set');
+      return NextResponse.json(
+        { error: 'Analytics service not configured' },
+        { status: 503 }
+      );
+    }
+
     const response = await fetch(LAMBDA_URL, {
       method: 'GET',
       headers: {
@@ -34,6 +42,14 @@ export async function GET() {
 // POST - Add page view or resume download
 export async function POST(request: NextRequest) {
   try {
+    if (!LAMBDA_URL) {
+      console.error('LAMBDA_URL environment variable is not set');
+      return NextResponse.json(
+        { error: 'Analytics service not configured' },
+        { status: 503 }
+      );
+    }
+
     const body = await request.json();
     const { type } = body;
 


### PR DESCRIPTION
This pull request adds error handling to the analytics API route to ensure the `LAMBDA_URL` environment variable is set before making requests. If `LAMBDA_URL` is missing, the API now returns a clear error response and logs the issue, improving reliability and debuggability.

**Environment variable validation and error handling:**

* Added checks in both the `GET` and `POST` handlers of `app/api/analytics/route.ts` to verify that `LAMBDA_URL` is set, returning a 503 error and logging an appropriate message if it is not. [[1]](diffhunk://#diff-3ae34a929b2d7be29c1949d28e1a7f3e113e276efbfd0a61c850d451a8ba87f0L2-R14) [[2]](diffhunk://#diff-3ae34a929b2d7be29c1949d28e1a7f3e113e276efbfd0a61c850d451a8ba87f0R45-R52)