### PR TITLE
fix(css): fixed typescript alignment issue

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -415,12 +415,12 @@ section {
   flex-wrap: wrap;
   flex-direction: row;
   gap: 2.5rem;
-  justify-content: space-around;
+  justify-content: flex-start;
 }
 
 article {
   display: flex;
-  width: 10rem;
+  /* width: 10rem; */
   justify-content: flex-start;
   align-items: flex-start;
   gap: 0.5rem;


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout styles in `app/globals.css` to improve the alignment of content within sections and articles.

- Layout adjustment:
  * Changed `justify-content` in the `section` selector from `space-around` to `flex-start` to align items to the start rather than distributing them evenly.
  * Commented out the fixed width in the `article` selector to allow for more flexible sizing.