### PR TITLE
fix(css): fixed typescript alignment issue

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -415,12 +415,12 @@ section {
   flex-wrap: wrap;
   flex-direction: row;
   gap: 2.5rem;
-  justify-content: space-around;
+  justify-content: flex-start;
 }
 
 article {
   display: flex;
-  width: 10rem;
+  /* width: 10rem; */
   justify-content: flex-start;
   align-items: flex-start;
   gap: 0.5rem;


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout styling in `app/globals.css`. The main change is updating the alignment of items within sections to start from the left, rather than being spaced around the container.

- Changed `justify-content` in the `section` CSS rule from `space-around` to `flex-start` to align child elements to the start of the flex container.
- Commented out the fixed width for `article` elements, allowing for more flexible sizing.