### PR TITLE
fix(css): fixed image size inconsistancy for project section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -450,10 +450,20 @@ article .icon {
   background: rgb(250, 250, 250);
 }
 
+.color-container .article-container {
+  width: 100%;
+  height: 250px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
 .project-img {
   border-radius: 2rem;
-  width: 90%;
-  height: 90%;
+  width: 100%;
+  height: 250px;
+  object-fit: cover;
 }
 
 .project-title {


### PR DESCRIPTION
This pull request updates the layout and styling for project images within article containers to improve their appearance and alignment. The main changes focus on ensuring images are consistently sized and properly centered within their containers.

Styling and layout improvements:

* Added a new `.color-container .article-container` CSS rule to ensure the container takes full width, has a fixed height of 250px, uses flexbox to center its content, and hides overflow for better image presentation.
* Updated the `.project-img` rule to set the width to 100%, height to 250px, and use `object-fit: cover` for consistent image scaling and cropping.